### PR TITLE
feat: add output path cli arg. change: copying and removing cache/out files

### DIFF
--- a/file/output.py
+++ b/file/output.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
 import shutil
-from os import path
+from os import path, remove
 
 import taglib
 
@@ -31,7 +31,8 @@ def copy_pod_to_output_dir(pod: Podcast | Episode,
                            output_dir: str,
                            cache_dir: str,
                            index: int, log: logging.Logger,
-                           retag_files: int = False) -> bool:
+                           retag_files: int = False,
+                           clear_cache: bool = False) -> bool:
     try:
         filename = f"{remove_spaces_from_string(f'{index:03} {pod.podcast} {pod.title}')}.MP3"
         print(f"Copying: {pod.podcast} - {pod.title} to output dir")
@@ -40,6 +41,9 @@ def copy_pod_to_output_dir(pod: Podcast | Episode,
                         )
         if retag_files:
             tag_file(pod, output_dir, filename, index)
+        if clear_cache:
+            print(f"Removing: {pod.podcast} - {pod.title} from cache")
+            remove(path.join(cache_dir, pod.uuid))
         return True
     except (FileNotFoundError, OSError) as e:
         log.error(f"Failed to copy podcast to output dir {e}")

--- a/file/output.py
+++ b/file/output.py
@@ -17,17 +17,6 @@ def create_output_dir_if_not_exists(directory: str, log: logging.Logger):
         log.error(f"Failed to create output dir {e}")
         raise SystemExit
 
-
-def clear_output_dir(directory: str, log: logging.Logger):
-    try:
-        for output_file in pathlib.Path(directory).glob("*"):
-            if output_file.is_file():
-                output_file.unlink()
-    except (FileNotFoundError, OSError) as e:
-        log.error(f"Failed to clear output dir {e}")
-        raise SystemExit
-
-
 def tag_file(pod: Podcast | Episode, output_dir: str, filename: str, index: int):
     with taglib.File(path.join(output_dir, filename), save_on_exit=True) as mp3_file:
         print(f"Tagging {pod.podcast}, {pod.title}")
@@ -69,22 +58,3 @@ def create_m3u_file(output_dir: str, filename: str):
     except (FileNotFoundError, OSError, IOError) as e:
         log.error(f"Failed to create m3u file {e}")
         raise SystemExit
-
-
-def copy_files(latest: list[Podcast | Episode], output_dir: str, cache_dir: str, retag_files: bool = False):
-    logger = logging.getLogger("__name__")
-    logger.info("Creating output dir")
-
-    clear_output_dir(output_dir, logger)
-    create_output_dir_if_not_exists(output_dir, logger)
-
-    index = 1
-
-    logger.info("Clearing output dir")
-
-    for podcast_ep in latest:
-        if copy_pod_to_output_dir(podcast_ep, output_dir, cache_dir, index, logger, retag_files):
-            index += 1
-        else:
-            logger.error(f"Failed to copy {podcast_ep.title} to output dir")
-            raise SystemExit

--- a/file/output.py
+++ b/file/output.py
@@ -17,6 +17,17 @@ def create_output_dir_if_not_exists(directory: str, log: logging.Logger):
         log.error(f"Failed to create output dir {e}")
         raise SystemExit
 
+
+def clear_output_dir(directory: str, log: logging.Logger):
+    try:
+        for output_file in pathlib.Path(directory).glob("*"):
+            if output_file.is_file() and output_file.suffix.lower() in [".mp3", ".m3u"]:
+                log.info(f"Removing file: {output_file}")
+                output_file.unlink()
+    except (FileNotFoundError, OSError) as e:
+        log.error(f"Failed to clear output dir {e}")
+        raise SystemExit
+
 def tag_file(pod: Podcast | Episode, output_dir: str, filename: str, index: int):
     with taglib.File(path.join(output_dir, filename), save_on_exit=True) as mp3_file:
         print(f"Tagging {pod.podcast}, {pod.title}")

--- a/pcdl.py
+++ b/pcdl.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     cached_eps = (get_uuid_in_cache_dir(CACHE_DIR, logger))
 
     # Check if the latest episodes are already in cache
-    check_if_downloaded = map(lambda x: return_cached_state(x, cached_eps), latest)
+    check_if_downloaded = list(map(lambda x: return_cached_state(x, cached_eps), latest))
 
     # Get the episodes that haven't been downloaded
     to_download = filter(lambda x: not x.downloaded, check_if_downloaded)

--- a/pcdl.py
+++ b/pcdl.py
@@ -3,7 +3,7 @@
 By default, will download the latest podcasts from your new releases feed
 
 Usage:
-    pcdl.py [--podcast PODCAST_UUID] [--output PATH] [--retag] [--number NUMTODL] [--min-podcast-length MINUTES] [--m3u-filename FILENAME]
+    pcdl.py [--podcast PODCAST_UUID] [--output PATH] [--retag] [--number NUMTODL] [--min-podcast-length MINUTES] [--m3u-filename FILENAME] [--clear-cache]
     pcdl.py (-h | --help)
 
 Options:
@@ -13,6 +13,7 @@ Options:
     --number NUMTODL                 Number of episodes to download [default: 30]
     --min-podcast-length MINUTES     Only download podcasts longer than this many minutes, to avoid downloading preview episodes etc
     --m3u-filename FILENAME          Name of the m3u file created in the output directory [default: playlist.m3u]
+    --clear-cache                    Clear cache as the files are being copied to the output dir
     -h --help                        Show this help message
 
 """
@@ -116,14 +117,14 @@ if __name__ == '__main__':
     # Copy cached
     for idx, podcast_ep in enumerate(downloaded):
         logging.info(f"Copying cached episode {podcast_ep.url} from {CACHE_DIR} to {os.path.realpath(OUTPUT_DIR)}")
-        copy_pod_to_output_dir(podcast_ep, OUTPUT_DIR, CACHE_DIR, idx + 1, logger, cl_args.get("--retag"))
+        copy_pod_to_output_dir(podcast_ep, OUTPUT_DIR, CACHE_DIR, idx + 1, logger, cl_args.get("--retag"), cl_args["--clear-cache"])
 
     print("Downloading undownloaded podcasts")
     for idx, podcast_ep in enumerate(to_download):
         logging.info(f"Downloading {podcast_ep.url}")
         print(f"Downloading {podcast_ep.podcast} - {podcast_ep.title}")
         download_podcast(podcast_ep, CACHE_DIR)
-        copy_pod_to_output_dir(podcast_ep, OUTPUT_DIR, CACHE_DIR, idx + 1, logger, cl_args.get("--retag"))
+        copy_pod_to_output_dir(podcast_ep, OUTPUT_DIR, CACHE_DIR, idx + 1, logger, cl_args.get("--retag"), cl_args["--clear-cache"])
 
 
     print("Creating m3u Playlist")

--- a/pcdl.py
+++ b/pcdl.py
@@ -3,7 +3,7 @@
 By default, will download the latest podcasts from your new releases feed
 
 Usage:
-    pcdl.py [--podcast PODCAST_UUID] [--output PATH] [--retag] [--number NUMTODL] [--min-podcast-length MINUTES] [--m3u-filename FILENAME] [--clear-cache]
+    pcdl.py [--podcast PODCAST_UUID] [--output PATH] [--retag] [--number NUMTODL] [--min-podcast-length MINUTES] [--m3u-filename FILENAME] [--clear-cache] [--clear-out]
     pcdl.py (-h | --help)
 
 Options:
@@ -14,6 +14,7 @@ Options:
     --min-podcast-length MINUTES     Only download podcasts longer than this many minutes, to avoid downloading preview episodes etc
     --m3u-filename FILENAME          Name of the m3u file created in the output directory [default: playlist.m3u]
     --clear-cache                    Clear cache as the files are being copied to the output dir
+    --clear-out                      Clears output dir
     -h --help                        Show this help message
 
 """
@@ -26,7 +27,7 @@ from dotenv import load_dotenv
 
 from auth.auth import authenticate
 from file.cache import get_uuid_in_cache_dir, prep_cache_dir, return_cached_state
-from file.output import create_m3u_file, create_output_dir_if_not_exists, copy_pod_to_output_dir
+from file.output import create_m3u_file, create_output_dir_if_not_exists, copy_pod_to_output_dir, clear_output_dir
 from net.download import download_podcast
 from podcast.episodes import get_single_podcast_episodes
 from podcast.pod import get_latest_episodes
@@ -113,6 +114,10 @@ if __name__ == '__main__':
     # Get the episodes that haven't been downloaded
     to_download = filter(lambda x: not x.downloaded, check_if_downloaded)
     downloaded = filter(lambda x: x.downloaded, check_if_downloaded)
+
+    # Clears output dir
+    if cl_args["--clear-out"]:
+        clear_output_dir(OUTPUT_DIR, logger)
 
     # Copy cached
     for idx, podcast_ep in enumerate(downloaded):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "sys_platform == 'darwin'",
@@ -15,36 +15,36 @@ dependencies = [
     { name = "idna" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094 }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097 },
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286 },
+    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
 ]
 
 [[package]]
 name = "docopt-ng"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/50/8d6806cf13138127692ae6ff79ddeb4e25eb3b0bcc3c1bd033e7e04531a9/docopt_ng-0.9.0.tar.gz", hash = "sha256:91c6da10b5bb6f2e9e25345829fb8278c78af019f6fc40887ad49b060483b1d7", size = 32264 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/50/8d6806cf13138127692ae6ff79ddeb4e25eb3b0bcc3c1bd033e7e04531a9/docopt_ng-0.9.0.tar.gz", hash = "sha256:91c6da10b5bb6f2e9e25345829fb8278c78af019f6fc40887ad49b060483b1d7", size = 32264, upload-time = "2023-05-30T20:46:25.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/4a/c3b77fc1a24510b08918b43a473410c0168f6e657118807015f1f1edceea/docopt_ng-0.9.0-py3-none-any.whl", hash = "sha256:bfe4c8b03f9fca424c24ee0b4ffa84bf7391cb18c29ce0f6a8227a3b01b81ff9", size = 16689 },
+    { url = "https://files.pythonhosted.org/packages/6c/4a/c3b77fc1a24510b08918b43a473410c0168f6e657118807015f1f1edceea/docopt_ng-0.9.0-py3-none-any.whl", hash = "sha256:bfe4c8b03f9fca424c24ee0b4ffa84bf7391cb18c29ce0f6a8227a3b01b81ff9", size = 16689, upload-time = "2023-05-30T20:46:45.294Z" },
 ]
 
 [[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -55,9 +55,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
 ]
 
 [[package]]
@@ -70,23 +70,23 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
 name = "pocketcasts-latest-downloader"
-version = "0.8.2"
+version = "0.8.4"
 source = { virtual = "." }
 dependencies = [
     { name = "anyio" },
@@ -96,7 +96,8 @@ dependencies = [
     { name = "httpcore" },
     { name = "httpx" },
     { name = "idna" },
-    { name = "pytaglib", marker = "sys_platform == 'darwin' or sys_platform == 'windows'" },
+    { name = "pytaglib", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "pytaglib", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or sys_platform == 'windows'" },
     { name = "python-dotenv" },
     { name = "sniffio" },
 ]
@@ -111,6 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "idna", specifier = "==3.11" },
     { name = "pytaglib", marker = "sys_platform == 'darwin'", specifier = ">=3.0.1" },
+    { name = "pytaglib", marker = "sys_platform == 'linux'", specifier = "==2.0.0" },
     { name = "pytaglib", marker = "sys_platform == 'windows'", specifier = ">=3.0.1" },
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "sniffio", specifier = "==1.3.1" },
@@ -118,28 +120,41 @@ requires-dist = [
 
 [[package]]
 name = "pytaglib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform != 'darwin' and sys_platform != 'windows'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/ad/38d631f242648200a5c8800c15ad3fd1b5390871b05563c2bed680ada75b/pytaglib-2.0.0.tar.gz", hash = "sha256:f62f45b7dd998ea81705bd228c2643ed743f5537543988d918955d5662b80737", size = 69138, upload-time = "2023-03-26T10:33:40.599Z" }
+
+[[package]]
+name = "pytaglib"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/f5/90d40088d4839b50b6aaa1de403d12053acfc7724901f7749d9724039882/pytaglib-3.0.1.tar.gz", hash = "sha256:b9255765d72e237e8b2843f2df3763f7ad3fdc6b6b3ffdd027c3f373c9bdd787", size = 500599 }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'windows'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f5/90d40088d4839b50b6aaa1de403d12053acfc7724901f7749d9724039882/pytaglib-3.0.1.tar.gz", hash = "sha256:b9255765d72e237e8b2843f2df3763f7ad3fdc6b6b3ffdd027c3f373c9bdd787", size = 500599, upload-time = "2025-03-21T22:32:51.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/f8/a2a9eaa79d200f5acf1d8a48b38db042668dc3e67bf56b569b11c5d30349/pytaglib-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1173675b8868498ed135cc488abfc70bc2016dc78f615a5b27adc042afd3ef9a", size = 765166 },
-    { url = "https://files.pythonhosted.org/packages/94/7e/739313be7611fd6f6d18407059255118ff4d09576afeacdd6246c2c98f1e/pytaglib-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b56cdbd3c029308634f4efa2134d91f74714eacfb6f43c0ed430fe74fa5cc09", size = 790362 },
+    { url = "https://files.pythonhosted.org/packages/ba/f8/a2a9eaa79d200f5acf1d8a48b38db042668dc3e67bf56b569b11c5d30349/pytaglib-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1173675b8868498ed135cc488abfc70bc2016dc78f615a5b27adc042afd3ef9a", size = 765166, upload-time = "2025-03-21T22:32:32.856Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7e/739313be7611fd6f6d18407059255118ff4d09576afeacdd6246c2c98f1e/pytaglib-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b56cdbd3c029308634f4efa2134d91f74714eacfb6f43c0ed430fe74fa5cc09", size = 790362, upload-time = "2025-03-21T22:32:33.913Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221 }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230 },
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]


### PR DESCRIPTION
closes #7 

this PR changes the following:

- Add output path as a CLI arg
- Change default behavior to **not** clearing the output dir
- Add `--clear-out` flag for clearing the output dir, limits it to just `.mp3` and `.m3u` files
- Copy files from cache to output as their are being downloaded
- Add `--clear-cache` flag, remove cached files as their are being copied to the output dir